### PR TITLE
Fix reverse-proxy failure

### DIFF
--- a/templates/application.template
+++ b/templates/application.template
@@ -752,7 +752,14 @@ Resources:
         Fn::Base64: !Sub |
           #!/bin/bash
           yum update -y
+          
+          # install SSL cert common key
+          yum -y install mod_ssl
 
+          aws configure set default.s3.signature_version s3v4
+          aws s3 cp s3://${rS3AssetsBucket}/ssl/common.crt /etc/ssl/certs/common.crt --region ${AWS::Region}
+          aws s3 cp s3://${rS3AssetsBucket}/ssl/common.key /etc/ssl/private/common.key --region ${AWS::Region}        
+          
           EC2_INSTANCE_ID=$(curl -s http://instance-data/latest/meta-data/instance-id)
 
           ######################################################################

--- a/templates/main.template
+++ b/templates/main.template
@@ -188,64 +188,64 @@ Mappings:
       AMZNLINUXHVM: amzn-ami-hvm-2018.03.0.20180412-x86_64-gp2
     ap-northeast-1:
       AMZNLINUXHVM: ami-28ddc154
-      InstanceType: t2.nano
-      InstanceTypeDatabase: db.t2.small
+      InstanceType: m4.large
+      InstanceTypeDatabase: db.m4.large
     ap-northeast-2:
       AMZNLINUXHVM: ami-efaf0181
-      InstanceType: t2.nano
-      InstanceTypeDatabase: db.t2.small
+      InstanceType: m4.large
+      InstanceTypeDatabase: db.m4.large
     ap-south-1:
       AMZNLINUXHVM: ami-b46f48db
-      InstanceType: t2.nano
-      InstanceTypeDatabase: db.t2.small
+      InstanceType: m4.large
+      InstanceTypeDatabase: db.m4.large
     ap-southeast-1:
       AMZNLINUXHVM: ami-64260718
-      InstanceType: t2.nano
-      InstanceTypeDatabase: db.t2.small
+      InstanceType: m4.large
+      InstanceTypeDatabase: db.m4.large
     ap-southeast-2:
       AMZNLINUXHVM: ami-60a26a02
-      InstanceType: t2.nano
-      InstanceTypeDatabase: db.t2.small
+      InstanceType: m4.large
+      InstanceTypeDatabase: db.m4.large
     ca-central-1:
       AMZNLINUXHVM: ami-2f39bf4b
-      InstanceType: t2.nano
-      InstanceTypeDatabase: db.t2.small
+      InstanceType: m4.large
+      InstanceTypeDatabase: db.m4.large
     eu-central-1:
       AMZNLINUXHVM: ami-1b316af0
-      InstanceType: t2.nano
-      InstanceTypeDatabase: db.t2.small
+      InstanceType: m4.large
+      InstanceTypeDatabase: db.m4.large
     eu-west-1:
       AMZNLINUXHVM: ami-9cbe9be5
-      InstanceType: t2.nano
-      InstanceTypeDatabase: db.t2.small
+      InstanceType: m4.large
+      InstanceTypeDatabase: db.m4.large
     eu-west-2:
       AMZNLINUXHVM: ami-c12dcda6
-      InstanceType: t2.nano
-      InstanceTypeDatabase: db.t2.small
+      InstanceType: m4.large
+      InstanceTypeDatabase: db.m4.large
     sa-east-1:
       AMZNLINUXHVM: ami-f09dcc9c
-      InstanceType: t2.nano
-      InstanceTypeDatabase: db.t2.small
+      InstanceType: m4.large
+      InstanceTypeDatabase: db.m3.large
     us-east-1:
       AMZNLINUXHVM: ami-467ca739
-      InstanceType: t2.nano
-      InstanceTypeDatabase: db.t2.small
+      InstanceType: m4.large
+      InstanceTypeDatabase: db.m4.large
     us-east-2:
       AMZNLINUXHVM: ami-976152f2
-      InstanceType: t2.nano
-      InstanceTypeDatabase: db.t2.small
+      InstanceType: m4.large
+      InstanceTypeDatabase: db.m4.large
     us-gov-west-1:
       AMZNLINUXHVM: ami-ffa61d9e
-      InstanceType: t2.nano
-      InstanceTypeDatabase: db.t2.small
+      InstanceType: m4.large
+      InstanceTypeDatabase: db.m3.large
     us-west-1:
       AMZNLINUXHVM: ami-46e1f226
-      InstanceType: t2.nano
-      InstanceTypeDatabase: db.t2.small
+      InstanceType: m4.large
+      InstanceTypeDatabase: db.m4.large
     us-west-2:
       AMZNLINUXHVM: ami-6b8cef13
-      InstanceType: t2.nano
-      InstanceTypeDatabase: db.t2.small
+      InstanceType: m4.large
+      InstanceTypeDatabase: db.m4.large
 Conditions:
   GovCloudCondition:
     !Equals
@@ -392,7 +392,7 @@ Resources:
           !If
           - LaunchAsDedicatedInstance
           - m4.large
-          - t2.nano
+          - t2.small
         pSupportsNatGateway:
           !FindInMap
           - RegionServiceSupport

--- a/templates/main.template
+++ b/templates/main.template
@@ -188,64 +188,64 @@ Mappings:
       AMZNLINUXHVM: amzn-ami-hvm-2018.03.0.20180412-x86_64-gp2
     ap-northeast-1:
       AMZNLINUXHVM: ami-28ddc154
-      InstanceType: m4.large
-      InstanceTypeDatabase: db.m4.large
+      InstanceType: t2.nano
+      InstanceTypeDatabase: db.t2.small
     ap-northeast-2:
       AMZNLINUXHVM: ami-efaf0181
-      InstanceType: m4.large
-      InstanceTypeDatabase: db.m4.large
+      InstanceType: t2.nano
+      InstanceTypeDatabase: db.t2.small
     ap-south-1:
       AMZNLINUXHVM: ami-b46f48db
-      InstanceType: m4.large
-      InstanceTypeDatabase: db.m4.large
+      InstanceType: t2.nano
+      InstanceTypeDatabase: db.t2.small
     ap-southeast-1:
       AMZNLINUXHVM: ami-64260718
-      InstanceType: m4.large
-      InstanceTypeDatabase: db.m4.large
+      InstanceType: t2.nano
+      InstanceTypeDatabase: db.t2.small
     ap-southeast-2:
       AMZNLINUXHVM: ami-60a26a02
-      InstanceType: m4.large
-      InstanceTypeDatabase: db.m4.large
+      InstanceType: t2.nano
+      InstanceTypeDatabase: db.t2.small
     ca-central-1:
       AMZNLINUXHVM: ami-2f39bf4b
-      InstanceType: m4.large
-      InstanceTypeDatabase: db.m4.large
+      InstanceType: t2.nano
+      InstanceTypeDatabase: db.t2.small
     eu-central-1:
       AMZNLINUXHVM: ami-1b316af0
-      InstanceType: m4.large
-      InstanceTypeDatabase: db.m4.large
+      InstanceType: t2.nano
+      InstanceTypeDatabase: db.t2.small
     eu-west-1:
       AMZNLINUXHVM: ami-9cbe9be5
-      InstanceType: m4.large
-      InstanceTypeDatabase: db.m4.large
+      InstanceType: t2.nano
+      InstanceTypeDatabase: db.t2.small
     eu-west-2:
       AMZNLINUXHVM: ami-c12dcda6
-      InstanceType: m4.large
-      InstanceTypeDatabase: db.m4.large
+      InstanceType: t2.nano
+      InstanceTypeDatabase: db.t2.small
     sa-east-1:
       AMZNLINUXHVM: ami-f09dcc9c
-      InstanceType: m4.large
-      InstanceTypeDatabase: db.m3.large
+      InstanceType: t2.nano
+      InstanceTypeDatabase: db.t2.small
     us-east-1:
       AMZNLINUXHVM: ami-467ca739
-      InstanceType: m4.large
-      InstanceTypeDatabase: db.m4.large
+      InstanceType: t2.nano
+      InstanceTypeDatabase: db.t2.small
     us-east-2:
       AMZNLINUXHVM: ami-976152f2
-      InstanceType: m4.large
-      InstanceTypeDatabase: db.m4.large
+      InstanceType: t2.nano
+      InstanceTypeDatabase: db.t2.small
     us-gov-west-1:
       AMZNLINUXHVM: ami-ffa61d9e
-      InstanceType: m4.large
-      InstanceTypeDatabase: db.m3.large
+      InstanceType: t2.nano
+      InstanceTypeDatabase: db.t2.small
     us-west-1:
       AMZNLINUXHVM: ami-46e1f226
-      InstanceType: m4.large
-      InstanceTypeDatabase: db.m4.large
+      InstanceType: t2.nano
+      InstanceTypeDatabase: db.t2.small
     us-west-2:
       AMZNLINUXHVM: ami-6b8cef13
-      InstanceType: m4.large
-      InstanceTypeDatabase: db.m4.large
+      InstanceType: t2.nano
+      InstanceTypeDatabase: db.t2.small
 Conditions:
   GovCloudCondition:
     !Equals
@@ -392,7 +392,7 @@ Resources:
           !If
           - LaunchAsDedicatedInstance
           - m4.large
-          - t2.small
+          - t2.nano
         pSupportsNatGateway:
           !FindInMap
           - RegionServiceSupport


### PR DESCRIPTION
The reverse-proxy servers are failing and showing unhealthy. The certificates were not copied to the server causing nginx to not restart. This fix adds the common.crt to the proxy-servers. 