### PR TITLE
Fix MetricName on CloudWatch Alarms  to a valid metic - CPUUtilization

### DIFF
--- a/templates/application.template
+++ b/templates/application.template
@@ -687,15 +687,12 @@ Resources:
             /tmp/nginx/default.conf:
               content: !Sub |
                 server {
-                    listen 80;
+                    listen       80 default_server;
+                    listen       [::]:80 default_server;
                     charset utf-8;
                     location / {
                         resolver xxxxx;
-                        set $elb 'https://${rELBApp.DNSName}';
-                        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-                        proxy_set_header Host $http_host;
-                        proxy_redirect off;
-                        proxy_pass $elb;
+                        return 301 https://$host$request_uri;
                     }
                 }
                 server {

--- a/templates/application.template
+++ b/templates/application.template
@@ -852,7 +852,7 @@ Resources:
       - Name: AutoScalingGroupName
         Value: !Ref rAutoScalingGroupWeb
       ComparisonOperator: GreaterThanThreshold
-      MetricName: WebServerCpuHighUtilization
+      MetricName: CPUUtilization
   rCWAlarmLowCPUWeb:
     Type: AWS::CloudWatch::Alarm
     DependsOn: rAutoScalingGroupWeb
@@ -869,7 +869,7 @@ Resources:
       - Name: AutoScalingGroupName
         Value: !Ref rAutoScalingGroupWeb
       ComparisonOperator: LessThanThreshold
-      MetricName: WebServerCpuLowUtilization
+      MetricName: CPUUtilization
   rAppInstanceRole:
     Type: AWS::IAM::Role
     Properties:
@@ -1170,7 +1170,7 @@ Resources:
       - Name: AutoScalingGroupName
         Value: !Ref rAutoScalingGroupApp
       ComparisonOperator: GreaterThanThreshold
-      MetricName: AppServerCpuHighUtilization
+      MetricName: CPUUtilization
   rCWAlarmLowCPUApp:
     Type: AWS::CloudWatch::Alarm
     Properties:
@@ -1186,7 +1186,7 @@ Resources:
       - Name: AutoScalingGroupName
         Value: !Ref rAutoScalingGroupApp
       ComparisonOperator: LessThanThreshold
-      MetricName: AppServerCpuLowUtilization
+      MetricName: CPUUtilization
   rPostProcInstanceRole:
     Type: AWS::IAM::Role
     Properties:


### PR DESCRIPTION
The MetricName: values specified in the template are not valid MetricName values. Although CloudFormation allows this to go through and doesn't error. The cloudwatch alarms do not work. They remain in INSUFFICIENT_DATA state indefinitely.  The MetricName need to be set to a valid metric in order for the Alarms to function properly. In this pull changed all the MetricName to CPUUtilization to get the Alarms to function correctly. 