### PR TITLE
Fixes unnecessary re-definition of QSS3KeyPrefix

### DIFF
--- a/templates/main.template
+++ b/templates/main.template
@@ -338,7 +338,7 @@ Resources:
           - !Ref AWS::Region
           - InstanceType
         QSS3BucketName: !Ref QSS3BucketName
-        QSS3KeyPrefix: !Sub ${QSS3KeyPrefix}submodules/quickstart-compliance-common/
+        QSS3KeyPrefix: !Ref QSS3KeyPrefix
   ManagementVpcTemplate:
     Type: AWS::CloudFormation::Stack
     DependsOn: ProductionVpcTemplate
@@ -409,7 +409,7 @@ Resources:
           - !Ref AWS::Region
           - InstanceType
         QSS3BucketName: !Ref QSS3BucketName
-        QSS3KeyPrefix: !Sub ${QSS3KeyPrefix}submodules/quickstart-compliance-common/
+        QSS3KeyPrefix: !Ref QSS3KeyPrefix
   ConfigRulesTemplate:
     Type: AWS::CloudFormation::Stack
     Condition: LoadConfigRulesTemplate


### PR DESCRIPTION
*Issue #, if available:*

Fixes #17

*Description of changes:*

The vpc-* templates in quickstart-compliance-common
expect QSS3KeyPrefix not to be re-defined,
which otherwise lead to errors when NAT Instances are
required.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
