### PR TITLE
Update aws-quickstart-graphic.png link

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -825,7 +825,7 @@ p.footer-text a{color:#d7d8d8}
 <h2 id="_quick_start_reference_deployment" class="discrete text-left text-center">Quick Start Reference Deployment</h2>
 <div class="imageblock text-center">
 <div class="content">
-<img src="https://aws-quickstart.s3.amazonaws.com/quickstart-compliance-hipaa/docs/boilerplate/.images/aws-quickstart-graphic.png" alt="QS" width="80" height="80">
+<img src="images/aws-quickstart-graphic.png" alt="QS" width="80" height="80">
 </div>
 </div>
 <h3 id="_draft_document_unofficial_guidance" class="discrete text-center">DRAFT DOCUMENT / UNOFFICIAL GUIDANCE</h3>


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
The current link, https://aws-quickstart.s3.amazonaws.com/quickstart-compliance-hipaa/docs/boilerplate/.images/aws-quickstart-graphic.png is not available from the https://aws-quickstart.github.io/quickstart-compliance-hipaa/ page.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
