### PR TITLE
PublicAccessBlockConfiguration updated on two S3 buckets in logging

### DIFF
--- a/templates/compliance-hipaa-logging.template.yaml
+++ b/templates/compliance-hipaa-logging.template.yaml
@@ -55,7 +55,8 @@ Resources:
     Type: 'AWS::S3::Bucket'
     DeletionPolicy: Retain
     Properties:
-      AccessControl: LogDeliveryWrite
+      PublicAccessBlockConfiguration:
+          BlockPublicPolicy: true
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
@@ -129,7 +130,8 @@ Resources:
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Properties:
-      AccessControl: LogDeliveryWrite
+      PublicAccessBlockConfiguration:
+          BlockPublicPolicy: true
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:


### PR DESCRIPTION
template
- Previous AccessControl configuration for S3 buckets (AWSCloudTrailBucket, AWSLoggingBucket) caused template to fail during create. Buckets updated to use PublicAccessBlockConfiguration and validated successful stack creation.

*Issue #, if available:* - previous configuration using AccessControl configuration fails out due to recent changes made by AWS in April of 2023. "For new buckets created after this date, S3 Block Public Access will be enabled, and S3 access control lists (ACLs) will be disabled."

*Description of changes:* - AccessControl configuration on buckets in logging template switched out for PublicAccessBlockConfiguration


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
